### PR TITLE
Integration tests to validate baseline agents

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,15 @@
     "packages/*",
     "packages/apps/*",
     "packages/baselines/*",
-    "packages/environments/*"
+    "packages/environments/*",
+    "tests/*"
   ],
+  "command": {
+    "publish": {
+      "ignoreChanges": [
+        "tests/*"
+      ]
+    }
+  },
   "version": "0.6.0"
 }

--- a/packages/apps/react/package-lock.json
+++ b/packages/apps/react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rl-js/react-app",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -277,262 +277,6 @@
         "d3-array": "1",
         "d3-collection": "1",
         "d3-interpolate": "1"
-      }
-    },
-    "@rl-js/baseline-agent-suites": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rl-js/baseline-agent-suites/-/baseline-agent-suites-0.5.1.tgz",
-      "integrity": "sha512-8DeyB1V3h1NB/IeY00XMethqWVMqo8gDpnQBYUX/cj8Td1s2a5cHsgrI0/v5ujaAsA+jzeoAJxsGTfSwUhYfDQ==",
-      "requires": {
-        "@rl-js/baseline-agents": "^0.5.1",
-        "@rl-js/baseline-function-approximators": "^0.5.1",
-        "@rl-js/baseline-policies": "^0.5.1",
-        "@rl-js/configuration": "^0.5.1",
-        "@rl-js/interfaces": "^0.5.1"
-      }
-    },
-    "@rl-js/baseline-agents": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rl-js/baseline-agents/-/baseline-agents-0.5.1.tgz",
-      "integrity": "sha512-0vNdphLD1+nW6vuOMk6N8/XS3HAqyDe1IfT8HtVcbDNbTOMLJiEx72scBI4lhsFJztXZ4ElIBbw+6el867TMCQ==",
-      "requires": {
-        "@rl-js/interfaces": "^1.7.0",
-        "check-interface": "^1.1.1",
-        "check-types": "^7.4.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "mathjs": "^5.0.4"
-      },
-      "dependencies": {
-        "@rl-js/interfaces": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@rl-js/interfaces/-/interfaces-1.7.0.tgz",
-          "integrity": "sha512-885aEU/lRqRp0qgUzn2Nr3foV8LlyOsZ2YxauGYZKQLDl1v4RfHLhM6lbm6LH8MsHgJ6CF9/5sBpPQGHnyFDPw==",
-          "requires": {
-            "check-interface": "^1.0.1"
-          }
-        }
-      }
-    },
-    "@rl-js/baseline-function-approximators": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rl-js/baseline-function-approximators/-/baseline-function-approximators-0.5.1.tgz",
-      "integrity": "sha512-Z/piByWOKCfAPmogVptiwpgpjDFN4u0bHRsSjSMA6nxqCzTKXix2tsdk3wi0IldB1cJFkWnlExfatCywPtVPdw==",
-      "requires": {
-        "@rl-js/interfaces": "^0.5.1",
-        "check-interface": "^1.1.1",
-        "js-combinatorics": "^0.5.3",
-        "lodash.mapvalues": "^4.6.0",
-        "mathjs": "^3.20.1"
-      },
-      "dependencies": {
-        "complex.js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.4.tgz",
-          "integrity": "sha512-Syl95HpxUTS0QjwNxencZsKukgh1zdS9uXeXX2Us0pHaqBR6kiZZi0AkZ9VpZFwHJyVIUVzI4EumjWdXP3fy6w=="
-        },
-        "decimal.js": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-9.0.1.tgz",
-          "integrity": "sha512-2h0iKbJwnImBk4TGk7CG1xadoA0g3LDPlQhQzbZ221zvG0p2YVUedbKIPsOZXKZGx6YmZMJKYOalpCMxSdDqTQ=="
-        },
-        "fraction.js": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.4.tgz",
-          "integrity": "sha512-aK/oGatyYLTtXRHjfEsytX5fieeR5H4s8sLorzcT12taFS+dbMZejnvm9gRa8mZAPwci24ucjq9epDyaq5u8Iw=="
-        },
-        "mathjs": {
-          "version": "3.20.2",
-          "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.20.2.tgz",
-          "integrity": "sha512-3f6/+uf1cUtIz1rYFz775wekl/UEDSQ3mU6xdxW7qzpvvhc2v28i3UtLsGTRB+u8OqDWoSX6Dz8gehaGFs6tCA==",
-          "requires": {
-            "complex.js": "2.0.4",
-            "decimal.js": "9.0.1",
-            "escape-latex": "^1.0.0",
-            "fraction.js": "4.0.4",
-            "javascript-natural-sort": "0.7.1",
-            "seed-random": "2.2.0",
-            "tiny-emitter": "2.0.2",
-            "typed-function": "0.10.7"
-          }
-        },
-        "typed-function": {
-          "version": "0.10.7",
-          "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.7.tgz",
-          "integrity": "sha512-3mlZ5AwRMbLvUKkc8a1TI4RUJUS2H27pmD5q0lHRObgsoWzhDAX01yg82kwSP1FUw922/4Y9ZliIEh0qJZcz+g=="
-        }
-      }
-    },
-    "@rl-js/baseline-policies": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rl-js/baseline-policies/-/baseline-policies-0.5.1.tgz",
-      "integrity": "sha512-49U5TydeaxtNVyMrXmR/0iBYhwg2fRqk5YO+9uPAshDMbFK3195DExBNPodr6tPy7n9+f5SjFz0vi84+XflcCw==",
-      "requires": {
-        "@rl-js/interfaces": "^0.5.1",
-        "gaussian": "^1.1.0",
-        "mathjs": "^3.20.2"
-      },
-      "dependencies": {
-        "complex.js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.4.tgz",
-          "integrity": "sha512-Syl95HpxUTS0QjwNxencZsKukgh1zdS9uXeXX2Us0pHaqBR6kiZZi0AkZ9VpZFwHJyVIUVzI4EumjWdXP3fy6w=="
-        },
-        "decimal.js": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-9.0.1.tgz",
-          "integrity": "sha512-2h0iKbJwnImBk4TGk7CG1xadoA0g3LDPlQhQzbZ221zvG0p2YVUedbKIPsOZXKZGx6YmZMJKYOalpCMxSdDqTQ=="
-        },
-        "fraction.js": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.4.tgz",
-          "integrity": "sha512-aK/oGatyYLTtXRHjfEsytX5fieeR5H4s8sLorzcT12taFS+dbMZejnvm9gRa8mZAPwci24ucjq9epDyaq5u8Iw=="
-        },
-        "mathjs": {
-          "version": "3.20.2",
-          "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.20.2.tgz",
-          "integrity": "sha512-3f6/+uf1cUtIz1rYFz775wekl/UEDSQ3mU6xdxW7qzpvvhc2v28i3UtLsGTRB+u8OqDWoSX6Dz8gehaGFs6tCA==",
-          "requires": {
-            "complex.js": "2.0.4",
-            "decimal.js": "9.0.1",
-            "escape-latex": "^1.0.0",
-            "fraction.js": "4.0.4",
-            "javascript-natural-sort": "0.7.1",
-            "seed-random": "2.2.0",
-            "tiny-emitter": "2.0.2",
-            "typed-function": "0.10.7"
-          }
-        },
-        "typed-function": {
-          "version": "0.10.7",
-          "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.7.tgz",
-          "integrity": "sha512-3mlZ5AwRMbLvUKkc8a1TI4RUJUS2H27pmD5q0lHRObgsoWzhDAX01yg82kwSP1FUw922/4Y9ZliIEh0qJZcz+g=="
-        }
-      }
-    },
-    "@rl-js/configuration": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rl-js/configuration/-/configuration-0.5.1.tgz",
-      "integrity": "sha512-RLfNO6DYsJQC2BWnBuXtCsh3ZcHMiyEjbky0wUKW8TbKN/esyCNXJA1ZLEtT9gf6hVWb4K/cOVySwTa3RFuHJg==",
-      "requires": {
-        "@rl-js/interfaces": "^0.5.1",
-        "check-interface": "^1.1.1",
-        "mathjs": "^5.1.1"
-      }
-    },
-    "@rl-js/environments-classic-control": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rl-js/environments-classic-control/-/environments-classic-control-0.5.1.tgz",
-      "integrity": "sha512-uwX2TkIQhNmY6Qx9t8Zma5IBLF9MZMYMTro7pAxg2s4+DSxepnelRb+IRhi7bIdsRnk05SbaU56tfTufrYLhgw==",
-      "requires": {
-        "@rl-js/configuration": "^1.0.0",
-        "@rl-js/interfaces": "^0.5.1",
-        "@rl-js/redux-mdp": "^0.5.1",
-        "lodash.get": "^4.4.2",
-        "mathjs": "^3.20.2",
-        "redux": "^3.7.2"
-      },
-      "dependencies": {
-        "@rl-js/configuration": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@rl-js/configuration/-/configuration-1.0.9.tgz",
-          "integrity": "sha512-h0LG1aiV6ipLjf9NnNCcbQDRm24U3U7tzs1TYznf1vMQvg75zJ6vytxJP74XC/BYOSO5kFZLG7ci00na8by/nA==",
-          "requires": {
-            "@rl-js/interfaces": "^1.6.0",
-            "check-interface": "^1.1.1",
-            "mathjs": "^5.1.1"
-          },
-          "dependencies": {
-            "@rl-js/interfaces": {
-              "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/@rl-js/interfaces/-/interfaces-1.7.0.tgz",
-              "integrity": "sha512-885aEU/lRqRp0qgUzn2Nr3foV8LlyOsZ2YxauGYZKQLDl1v4RfHLhM6lbm6LH8MsHgJ6CF9/5sBpPQGHnyFDPw==",
-              "requires": {
-                "check-interface": "^1.0.1"
-              }
-            },
-            "mathjs": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.1.1.tgz",
-              "integrity": "sha512-KRRoX+KU/3rA3CPx3cjk+8V2lSAIQ/fQ+v9n0KZ1zFb9/0MbWt+QKxFhYMM9EHsr+9XD3WMOsO9PGF1yL2hhMQ==",
-              "requires": {
-                "complex.js": "2.0.11",
-                "decimal.js": "10.0.1",
-                "escape-latex": "1.1.1",
-                "fraction.js": "4.0.8",
-                "javascript-natural-sort": "0.7.1",
-                "seed-random": "2.2.0",
-                "tiny-emitter": "2.0.2",
-                "typed-function": "1.1.0"
-              }
-            }
-          }
-        },
-        "mathjs": {
-          "version": "3.20.2",
-          "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.20.2.tgz",
-          "integrity": "sha512-3f6/+uf1cUtIz1rYFz775wekl/UEDSQ3mU6xdxW7qzpvvhc2v28i3UtLsGTRB+u8OqDWoSX6Dz8gehaGFs6tCA==",
-          "requires": {
-            "complex.js": "2.0.4",
-            "decimal.js": "9.0.1",
-            "escape-latex": "^1.0.0",
-            "fraction.js": "4.0.4",
-            "javascript-natural-sort": "0.7.1",
-            "seed-random": "2.2.0",
-            "tiny-emitter": "2.0.2",
-            "typed-function": "0.10.7"
-          },
-          "dependencies": {
-            "complex.js": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.4.tgz",
-              "integrity": "sha512-Syl95HpxUTS0QjwNxencZsKukgh1zdS9uXeXX2Us0pHaqBR6kiZZi0AkZ9VpZFwHJyVIUVzI4EumjWdXP3fy6w=="
-            },
-            "decimal.js": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-9.0.1.tgz",
-              "integrity": "sha512-2h0iKbJwnImBk4TGk7CG1xadoA0g3LDPlQhQzbZ221zvG0p2YVUedbKIPsOZXKZGx6YmZMJKYOalpCMxSdDqTQ=="
-            },
-            "fraction.js": {
-              "version": "4.0.4",
-              "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.4.tgz",
-              "integrity": "sha512-aK/oGatyYLTtXRHjfEsytX5fieeR5H4s8sLorzcT12taFS+dbMZejnvm9gRa8mZAPwci24ucjq9epDyaq5u8Iw=="
-            },
-            "typed-function": {
-              "version": "0.10.7",
-              "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.7.tgz",
-              "integrity": "sha512-3mlZ5AwRMbLvUKkc8a1TI4RUJUS2H27pmD5q0lHRObgsoWzhDAX01yg82kwSP1FUw922/4Y9ZliIEh0qJZcz+g=="
-            }
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-          "requires": {
-            "lodash": "^4.2.1",
-            "lodash-es": "^4.2.1",
-            "loose-envify": "^1.1.0",
-            "symbol-observable": "^1.0.3"
-          }
-        }
-      }
-    },
-    "@rl-js/interfaces": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rl-js/interfaces/-/interfaces-0.5.1.tgz",
-      "integrity": "sha512-b/ENyDeseH0Kg062vV0r3mHXkNBMzbz1tYYRAu8TxS2Haafhp7B2swDpxrE+o05rI0LXmGPbvMChF6QVLogZlQ==",
-      "requires": {
-        "check-interface": "^1.0.1"
-      }
-    },
-    "@rl-js/redux-mdp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rl-js/redux-mdp/-/redux-mdp-0.5.1.tgz",
-      "integrity": "sha512-Q9DXV6S5k6HFn7Dd++Pwu1XAkOaJc5H191ggmR9fWb4xgs5ZUQmcseRXVW0G02bF1eNwMWYep4ML0VdxUQShMQ==",
-      "requires": {
-        "@rl-js/interfaces": "^0.5.1",
-        "redux": "^4.0.0"
       }
     },
     "@storybook/addon-actions": {
@@ -4225,16 +3969,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
-    "check-interface": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/check-interface/-/check-interface-1.1.1.tgz",
-      "integrity": "sha512-ULbuRQPyDzvAI2UEp4exZYUNO4+ZU2hAGlHLDpbjUmKoEKLXzcCJUbnUhDgziYj2UJ2hVn72KhNqLIaXAyhmOQ=="
-    },
-    "check-types": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
-      "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
-    },
     "chokidar": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
@@ -7919,11 +7653,6 @@
         }
       }
     },
-    "gaussian": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gaussian/-/gaussian-1.1.0.tgz",
-      "integrity": "sha1-bRN6CX1Nv8ILUvsctdYcRwDt13E="
-    },
     "geojson-rewind": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.3.1.tgz",
@@ -11070,11 +10799,6 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -11104,11 +10828,6 @@
         "lodash.isarray": "^3.0.0"
       }
     },
-    "lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11119,11 +10838,6 @@
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.some": {
       "version": "4.6.0",

--- a/packages/baselines/agents/package-lock.json
+++ b/packages/baselines/agents/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rl-js/baseline-agents",
-  "version": "0.0.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/baselines/function-approximators/package-lock.json
+++ b/packages/baselines/function-approximators/package-lock.json
@@ -1,17 +1,9 @@
 {
   "name": "@rl-js/baseline-function-approximators",
-  "version": "0.0.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@rl-js/interfaces": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@rl-js/interfaces/-/interfaces-0.0.5.tgz",
-      "integrity": "sha512-S+cJVzjy6hNWo1/X7rexLD9F/6me4f6ECAUzP9uhOVAlclzBo0yz4/QxQMg5iiL7UTSOmLTkvuh+Iduy79TGYA==",
-      "requires": {
-        "check-interface": "^1.0.1"
-      }
-    },
     "check-interface": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/check-interface/-/check-interface-1.1.1.tgz",

--- a/packages/baselines/policies/package-lock.json
+++ b/packages/baselines/policies/package-lock.json
@@ -1,22 +1,9 @@
 {
   "name": "@rl-js/baseline-policies",
-  "version": "0.0.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@rl-js/interfaces": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@rl-js/interfaces/-/interfaces-0.0.5.tgz",
-      "integrity": "sha512-S+cJVzjy6hNWo1/X7rexLD9F/6me4f6ECAUzP9uhOVAlclzBo0yz4/QxQMg5iiL7UTSOmLTkvuh+Iduy79TGYA==",
-      "requires": {
-        "check-interface": "^1.0.1"
-      }
-    },
-    "check-interface": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/check-interface/-/check-interface-1.1.1.tgz",
-      "integrity": "sha512-ULbuRQPyDzvAI2UEp4exZYUNO4+ZU2hAGlHLDpbjUmKoEKLXzcCJUbnUhDgziYj2UJ2hVn72KhNqLIaXAyhmOQ=="
-    },
     "complex.js": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.4.tgz",

--- a/packages/configuration/package-lock.json
+++ b/packages/configuration/package-lock.json
@@ -1,17 +1,9 @@
 {
   "name": "@rl-js/configuration",
-  "version": "0.0.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@rl-js/interfaces": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@rl-js/interfaces/-/interfaces-0.0.5.tgz",
-      "integrity": "sha512-S+cJVzjy6hNWo1/X7rexLD9F/6me4f6ECAUzP9uhOVAlclzBo0yz4/QxQMg5iiL7UTSOmLTkvuh+Iduy79TGYA==",
-      "requires": {
-        "check-interface": "^1.0.1"
-      }
-    },
     "check-interface": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/check-interface/-/check-interface-1.1.1.tgz",

--- a/tests/integration/package-lock.json
+++ b/tests/integration/package-lock.json
@@ -1,0 +1,393 @@
+{
+  "name": "@rl-js/tests-integration",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@rl-js/baseline-agent-suites": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rl-js/baseline-agent-suites/-/baseline-agent-suites-0.6.0.tgz",
+      "integrity": "sha512-mOxi/g5YNO/e42JQPlkIrn2ilyriLzI2AEsRFz46IqHMRQC+EnN8j8SLl7a/vDXceMXzoF1SZgzrlsTZ2IuVdw==",
+      "requires": {
+        "@rl-js/baseline-agents": "^0.6.0",
+        "@rl-js/baseline-function-approximators": "^0.6.0",
+        "@rl-js/baseline-policies": "^0.6.0",
+        "@rl-js/configuration": "^0.6.0",
+        "@rl-js/interfaces": "^0.6.0"
+      }
+    },
+    "@rl-js/baseline-agents": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rl-js/baseline-agents/-/baseline-agents-0.6.0.tgz",
+      "integrity": "sha512-pdlMQMPXet09IIQHfQr7z6hS+FFVQfFzKt+6Wvez2jFJDZeJMCvK8fViMbJ7reE+OSSI5KFs2zrpaQ1+qBB8pA==",
+      "requires": {
+        "@rl-js/interfaces": "^1.7.0",
+        "check-interface": "^1.1.1",
+        "check-types": "^7.4.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "mathjs": "^5.0.4"
+      },
+      "dependencies": {
+        "@rl-js/interfaces": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@rl-js/interfaces/-/interfaces-1.7.0.tgz",
+          "integrity": "sha512-885aEU/lRqRp0qgUzn2Nr3foV8LlyOsZ2YxauGYZKQLDl1v4RfHLhM6lbm6LH8MsHgJ6CF9/5sBpPQGHnyFDPw==",
+          "requires": {
+            "check-interface": "^1.0.1"
+          }
+        }
+      }
+    },
+    "@rl-js/baseline-function-approximators": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rl-js/baseline-function-approximators/-/baseline-function-approximators-0.6.0.tgz",
+      "integrity": "sha512-65MiZ5twPTz26r8Nw6jhaep2whq/hI9Ku8W+dX0XGdM0UJE9Cmh6vXEHy9KJS+M00luACDGjiexnDsBYrVwetg==",
+      "requires": {
+        "@rl-js/interfaces": "^0.6.0",
+        "check-interface": "^1.1.1",
+        "js-combinatorics": "^0.5.3",
+        "lodash.mapvalues": "^4.6.0",
+        "mathjs": "^3.20.1"
+      },
+      "dependencies": {
+        "complex.js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.4.tgz",
+          "integrity": "sha512-Syl95HpxUTS0QjwNxencZsKukgh1zdS9uXeXX2Us0pHaqBR6kiZZi0AkZ9VpZFwHJyVIUVzI4EumjWdXP3fy6w=="
+        },
+        "decimal.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-9.0.1.tgz",
+          "integrity": "sha512-2h0iKbJwnImBk4TGk7CG1xadoA0g3LDPlQhQzbZ221zvG0p2YVUedbKIPsOZXKZGx6YmZMJKYOalpCMxSdDqTQ=="
+        },
+        "fraction.js": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.4.tgz",
+          "integrity": "sha512-aK/oGatyYLTtXRHjfEsytX5fieeR5H4s8sLorzcT12taFS+dbMZejnvm9gRa8mZAPwci24ucjq9epDyaq5u8Iw=="
+        },
+        "mathjs": {
+          "version": "3.20.2",
+          "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.20.2.tgz",
+          "integrity": "sha512-3f6/+uf1cUtIz1rYFz775wekl/UEDSQ3mU6xdxW7qzpvvhc2v28i3UtLsGTRB+u8OqDWoSX6Dz8gehaGFs6tCA==",
+          "requires": {
+            "complex.js": "2.0.4",
+            "decimal.js": "9.0.1",
+            "escape-latex": "^1.0.0",
+            "fraction.js": "4.0.4",
+            "javascript-natural-sort": "0.7.1",
+            "seed-random": "2.2.0",
+            "tiny-emitter": "2.0.2",
+            "typed-function": "0.10.7"
+          }
+        },
+        "typed-function": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.7.tgz",
+          "integrity": "sha512-3mlZ5AwRMbLvUKkc8a1TI4RUJUS2H27pmD5q0lHRObgsoWzhDAX01yg82kwSP1FUw922/4Y9ZliIEh0qJZcz+g=="
+        }
+      }
+    },
+    "@rl-js/baseline-policies": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rl-js/baseline-policies/-/baseline-policies-0.6.0.tgz",
+      "integrity": "sha512-yEE/qORCXjQG/aYjp0j2f7H4zgiOiMgdiMnoyWKfuNXtL+xfaU5oG0KNXsT71jZJLbVzEWhjujAwEktB6ZXkpA==",
+      "requires": {
+        "@rl-js/interfaces": "^0.6.0",
+        "gaussian": "^1.1.0",
+        "mathjs": "^3.20.2"
+      },
+      "dependencies": {
+        "complex.js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.4.tgz",
+          "integrity": "sha512-Syl95HpxUTS0QjwNxencZsKukgh1zdS9uXeXX2Us0pHaqBR6kiZZi0AkZ9VpZFwHJyVIUVzI4EumjWdXP3fy6w=="
+        },
+        "decimal.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-9.0.1.tgz",
+          "integrity": "sha512-2h0iKbJwnImBk4TGk7CG1xadoA0g3LDPlQhQzbZ221zvG0p2YVUedbKIPsOZXKZGx6YmZMJKYOalpCMxSdDqTQ=="
+        },
+        "fraction.js": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.4.tgz",
+          "integrity": "sha512-aK/oGatyYLTtXRHjfEsytX5fieeR5H4s8sLorzcT12taFS+dbMZejnvm9gRa8mZAPwci24ucjq9epDyaq5u8Iw=="
+        },
+        "mathjs": {
+          "version": "3.20.2",
+          "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.20.2.tgz",
+          "integrity": "sha512-3f6/+uf1cUtIz1rYFz775wekl/UEDSQ3mU6xdxW7qzpvvhc2v28i3UtLsGTRB+u8OqDWoSX6Dz8gehaGFs6tCA==",
+          "requires": {
+            "complex.js": "2.0.4",
+            "decimal.js": "9.0.1",
+            "escape-latex": "^1.0.0",
+            "fraction.js": "4.0.4",
+            "javascript-natural-sort": "0.7.1",
+            "seed-random": "2.2.0",
+            "tiny-emitter": "2.0.2",
+            "typed-function": "0.10.7"
+          }
+        },
+        "typed-function": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.7.tgz",
+          "integrity": "sha512-3mlZ5AwRMbLvUKkc8a1TI4RUJUS2H27pmD5q0lHRObgsoWzhDAX01yg82kwSP1FUw922/4Y9ZliIEh0qJZcz+g=="
+        }
+      }
+    },
+    "@rl-js/configuration": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rl-js/configuration/-/configuration-0.6.0.tgz",
+      "integrity": "sha512-ZMlHLnfv8JNGv3tmwmLcwN/yuy9KM8BCzlHaBb4SHgXoV1vfipWL1DWS3IZ6/BHbqVr6MqIfgqu3h0UH37rrEw==",
+      "requires": {
+        "@rl-js/interfaces": "^0.6.0",
+        "check-interface": "^1.1.1",
+        "mathjs": "^5.1.1"
+      }
+    },
+    "@rl-js/environments-classic-control": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rl-js/environments-classic-control/-/environments-classic-control-0.6.0.tgz",
+      "integrity": "sha512-Kf65hz36WTSY3slYCHR6J43HlbQsI4+p7mHUM5jrFPRTRnEV9sG3nqp1o34Ssbl0E+ummV74MlJQJSLLzjw1og==",
+      "requires": {
+        "@rl-js/configuration": "^1.0.0",
+        "@rl-js/interfaces": "^0.6.0",
+        "@rl-js/redux-mdp": "^0.6.0",
+        "lodash.get": "^4.4.2",
+        "mathjs": "^3.20.2",
+        "redux": "^3.7.2"
+      },
+      "dependencies": {
+        "@rl-js/configuration": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/@rl-js/configuration/-/configuration-1.0.9.tgz",
+          "integrity": "sha512-h0LG1aiV6ipLjf9NnNCcbQDRm24U3U7tzs1TYznf1vMQvg75zJ6vytxJP74XC/BYOSO5kFZLG7ci00na8by/nA==",
+          "requires": {
+            "@rl-js/interfaces": "^1.6.0",
+            "check-interface": "^1.1.1",
+            "mathjs": "^5.1.1"
+          },
+          "dependencies": {
+            "@rl-js/interfaces": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/@rl-js/interfaces/-/interfaces-1.7.0.tgz",
+              "integrity": "sha512-885aEU/lRqRp0qgUzn2Nr3foV8LlyOsZ2YxauGYZKQLDl1v4RfHLhM6lbm6LH8MsHgJ6CF9/5sBpPQGHnyFDPw==",
+              "requires": {
+                "check-interface": "^1.0.1"
+              }
+            },
+            "mathjs": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.1.1.tgz",
+              "integrity": "sha512-KRRoX+KU/3rA3CPx3cjk+8V2lSAIQ/fQ+v9n0KZ1zFb9/0MbWt+QKxFhYMM9EHsr+9XD3WMOsO9PGF1yL2hhMQ==",
+              "requires": {
+                "complex.js": "2.0.11",
+                "decimal.js": "10.0.1",
+                "escape-latex": "1.1.1",
+                "fraction.js": "4.0.8",
+                "javascript-natural-sort": "0.7.1",
+                "seed-random": "2.2.0",
+                "tiny-emitter": "2.0.2",
+                "typed-function": "1.1.0"
+              }
+            }
+          }
+        },
+        "mathjs": {
+          "version": "3.20.2",
+          "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.20.2.tgz",
+          "integrity": "sha512-3f6/+uf1cUtIz1rYFz775wekl/UEDSQ3mU6xdxW7qzpvvhc2v28i3UtLsGTRB+u8OqDWoSX6Dz8gehaGFs6tCA==",
+          "requires": {
+            "complex.js": "2.0.4",
+            "decimal.js": "9.0.1",
+            "escape-latex": "^1.0.0",
+            "fraction.js": "4.0.4",
+            "javascript-natural-sort": "0.7.1",
+            "seed-random": "2.2.0",
+            "tiny-emitter": "2.0.2",
+            "typed-function": "0.10.7"
+          },
+          "dependencies": {
+            "complex.js": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.4.tgz",
+              "integrity": "sha512-Syl95HpxUTS0QjwNxencZsKukgh1zdS9uXeXX2Us0pHaqBR6kiZZi0AkZ9VpZFwHJyVIUVzI4EumjWdXP3fy6w=="
+            },
+            "decimal.js": {
+              "version": "9.0.1",
+              "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-9.0.1.tgz",
+              "integrity": "sha512-2h0iKbJwnImBk4TGk7CG1xadoA0g3LDPlQhQzbZ221zvG0p2YVUedbKIPsOZXKZGx6YmZMJKYOalpCMxSdDqTQ=="
+            },
+            "fraction.js": {
+              "version": "4.0.4",
+              "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.4.tgz",
+              "integrity": "sha512-aK/oGatyYLTtXRHjfEsytX5fieeR5H4s8sLorzcT12taFS+dbMZejnvm9gRa8mZAPwci24ucjq9epDyaq5u8Iw=="
+            },
+            "typed-function": {
+              "version": "0.10.7",
+              "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.7.tgz",
+              "integrity": "sha512-3mlZ5AwRMbLvUKkc8a1TI4RUJUS2H27pmD5q0lHRObgsoWzhDAX01yg82kwSP1FUw922/4Y9ZliIEh0qJZcz+g=="
+            }
+          }
+        }
+      }
+    },
+    "@rl-js/interfaces": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rl-js/interfaces/-/interfaces-0.6.0.tgz",
+      "integrity": "sha512-Ei7oAIKgIScAPWZdJqcNQQIsXA86dPKpVl6+1klr1hjdcUlVwrT6v9HvEibtMC8R/ooYo/8SVxnUVx4bueXIYA==",
+      "requires": {
+        "check-interface": "^1.0.1"
+      }
+    },
+    "@rl-js/redux-mdp": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rl-js/redux-mdp/-/redux-mdp-0.6.0.tgz",
+      "integrity": "sha512-QLV+IAHBQ606+mMXmx6K8iM76I+OB9X/tGOAUy1eYrcAGh868etPZkXLrDSme9WsL3s+VAoCmS/G3vIBVahZQw==",
+      "requires": {
+        "@rl-js/interfaces": "^0.6.0",
+        "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+          "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
+      }
+    },
+    "check-interface": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/check-interface/-/check-interface-1.1.1.tgz",
+      "integrity": "sha512-ULbuRQPyDzvAI2UEp4exZYUNO4+ZU2hAGlHLDpbjUmKoEKLXzcCJUbnUhDgziYj2UJ2hVn72KhNqLIaXAyhmOQ=="
+    },
+    "check-types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
+      "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
+    },
+    "complex.js": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.11.tgz",
+      "integrity": "sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw=="
+    },
+    "decimal.js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.0.1.tgz",
+      "integrity": "sha512-vklWB5C4Cj423xnaOtsUmAv0/7GqlXIgDv2ZKDyR64OV3OSzGHNx2mk4p/1EKnB5s70k73cIOOEcG9YzF0q4Lw=="
+    },
+    "escape-latex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.1.1.tgz",
+      "integrity": "sha512-N2D6Z2kXh8x/pQNQH+natXDCwrzghhXMRII5dZ518mlTLeuba80NL0LCQyaahqOrAidoLivmmG6GKPnGhHse+A=="
+    },
+    "fraction.js": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.8.tgz",
+      "integrity": "sha512-8Jx2AkFIFQtFaF8wP7yUIW+lnCgzPbxsholryMZ+oPK6kKjY/nUrvMKtq1+A8aSAeFau7+G/zfO8aGk2Aw1wCA=="
+    },
+    "gaussian": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gaussian/-/gaussian-1.1.0.tgz",
+      "integrity": "sha1-bRN6CX1Nv8ILUvsctdYcRwDt13E="
+    },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+    },
+    "js-combinatorics": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-0.5.3.tgz",
+      "integrity": "sha512-egCSKDP7vcTlwSyIVuipmGc4Btxpb8ftQ+dhRMgQHJ9JwifXS/yBeTokLADjoJmip4T20yEMJK4YT/DNkOTUtQ=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "lodash-es": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.mapvalues": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "mathjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.1.1.tgz",
+      "integrity": "sha512-KRRoX+KU/3rA3CPx3cjk+8V2lSAIQ/fQ+v9n0KZ1zFb9/0MbWt+QKxFhYMM9EHsr+9XD3WMOsO9PGF1yL2hhMQ==",
+      "requires": {
+        "complex.js": "2.0.11",
+        "decimal.js": "10.0.1",
+        "escape-latex": "1.1.1",
+        "fraction.js": "4.0.8",
+        "javascript-natural-sort": "0.7.1",
+        "seed-random": "2.2.0",
+        "tiny-emitter": "2.0.2",
+        "typed-function": "1.1.0"
+      }
+    },
+    "redux": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "requires": {
+        "lodash": "^4.2.1",
+        "lodash-es": "^4.2.1",
+        "loose-envify": "^1.1.0",
+        "symbol-observable": "^1.0.3"
+      }
+    },
+    "seed-random": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+      "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
+    },
+    "typed-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-1.1.0.tgz",
+      "integrity": "sha512-TuQzwiT4DDg19beHam3E66oRXhyqlyfgjHB/5fcvsRXbfmWPJfto9B4a0TBdTrQAPGlGmXh/k7iUI+WsObgORA=="
+    }
+  }
+}

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@rl-js/tests-integration",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Integration tests for @rl-js baselines",
+  "main": "suites.test.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "rl-js"
+  ],
+  "author": "cpnota@gmail.com",
+  "license": "MIT",
+  "dependencies": {
+    "@rl-js/baseline-agent-suites": "^0.6.0",
+    "@rl-js/configuration": "^0.6.0",
+    "@rl-js/environments-classic-control": "^0.6.0"
+  }
+}

--- a/tests/integration/suites.test.js
+++ b/tests/integration/suites.test.js
@@ -1,0 +1,30 @@
+const configuration = require('@rl-js/configuration');
+configuration.registerAgentSuite(require('@rl-js/baseline-agent-suites'));
+configuration.registerEnvironmentSuite(require('@rl-js/environments-classic-control'));
+
+configuration.listAgentSuites().forEach((agentSuite) => {
+  const environmentType = agentSuite.getEnvironmentType();
+  const environmentSuites = configuration.listEnvironmentSuites(environmentType);
+  agentSuite.listAgents().forEach((agentBuilder) => {
+    environmentSuites.forEach((environmentSuite) => {
+      environmentSuite.listEnvironments().forEach((environmentBuilder) => {
+        test(`${agentBuilder.getName()} | ${environmentSuite.getName()} | ${environmentBuilder.getName()}`,
+          () => {
+            const environmentFactory = environmentBuilder.buildFactory();
+            const agentFactory = agentBuilder
+              .setEnvironmentFactory(environmentFactory)
+              .buildFactory();
+
+            const environment = environmentFactory.createEnvironment();
+            const agent = agentFactory.createAgent();
+            agent.newEpisode(environment);
+
+            for (let t = 0; t < 3; t += 1) {
+              agent.act();
+            }
+          },
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add `/tests/integration` package, which iterates over all baseline agent suites, and classic control suites, and tests each agent/environment combo for three time steps, to ensure that the code does not crash. The purpose is not to ensure that the agents work *well*, or even *correctly*, just to validate that at the most basic level, they run properly.