### PR TITLE
use vector.dot instead of math.dot in fourier

### DIFF
--- a/packages/baselines/function-approximators/generic/linear/bases/fourier-cos.js
+++ b/packages/baselines/function-approximators/generic/linear/bases/fourier-cos.js
@@ -1,4 +1,5 @@
 const math = require('mathjs');
+const { vector } = require('@rl-js/math');
 const { cartesianProduct } = require('js-combinatorics');
 const Basis = require('../basis');
 const Cache = require('../../../utils/cache');
@@ -18,7 +19,7 @@ class FourierCosBasis extends Basis {
 
   features(x) {
     /* eslint-disable camelcase */
-    return this.c.map(c_i => Math.cos(Math.PI * math.dot(c_i, x)));
+    return this.c.map(c_i => Math.cos(vector.dot(c_i, x)));
   }
 
   getNumberOfFeatures() {
@@ -26,7 +27,7 @@ class FourierCosBasis extends Basis {
   }
 
   computeC() {
-    const powerRange = math.range(0, this.order + 1).toArray();
+    const powerRange = math.range(0, this.order + 1).toArray().map(x => Math.PI * x);
     const possiblePowers = new Array(this.variables).fill(powerRange);
     return cartesianProduct(...possiblePowers).toArray();
   }

--- a/packages/baselines/function-approximators/generic/linear/bases/fourier-cos.spec.js
+++ b/packages/baselines/function-approximators/generic/linear/bases/fourier-cos.spec.js
@@ -15,6 +15,8 @@ it('computes features', () => {
   expect(features[3]).toBeCloseTo(-0.588, 3);
 });
 
+const removePI = matr => matr.map(arr => arr.map(v => v / Math.PI));
+
 describe('c', () => {
   it('computes c correctly for 2x0', () => {
     const basis = new FourierBasis({
@@ -22,7 +24,7 @@ describe('c', () => {
       order: 0,
     });
 
-    expect(basis.c).toEqual([[0, 0]]);
+    expect(removePI(basis.c)).toEqual([[0, 0]]);
   });
 
   it('computes c correctly for 2x1', () => {
@@ -31,7 +33,7 @@ describe('c', () => {
       order: 1,
     });
 
-    expect(basis.c).toEqual([[0, 0], [1, 0], [0, 1], [1, 1]]);
+    expect(removePI(basis.c)).toEqual([[0, 0], [1, 0], [0, 1], [1, 1]]);
   });
 
   it('computes c correctly for 2x2', () => {
@@ -40,7 +42,7 @@ describe('c', () => {
       order: 2,
     });
 
-    expect(basis.c).toEqual([
+    expect(removePI(basis.c)).toEqual([
       [0, 0],
       [1, 0],
       [2, 0],
@@ -59,7 +61,7 @@ describe('c', () => {
       order: 1,
     });
 
-    expect(basis.c).toEqual([
+    expect(removePI(basis.c)).toEqual([
       [0, 0, 0],
       [1, 0, 0],
       [0, 1, 0],

--- a/packages/baselines/function-approximators/generic/linear/bases/fourier.js
+++ b/packages/baselines/function-approximators/generic/linear/bases/fourier.js
@@ -1,4 +1,5 @@
 const math = require('mathjs');
+const { vector } = require('@rl-js/math');
 const { cartesianProduct } = require('js-combinatorics');
 const Basis = require('../basis');
 const Cache = require('../../../utils/cache');
@@ -27,8 +28,9 @@ class FourierBasis extends Basis {
     const features = [];
     /* eslint-disable camelcase */
     this.c.forEach((c_i) => {
-      features.push(Math.cos(Math.PI * math.dot(c_i, x)));
-      features.push(Math.sin(Math.PI * math.dot(c_i, x)));
+      const v = vector.dot(c_i, x);
+      features.push(Math.cos(v));
+      features.push(Math.sin(v));
     });
     return features;
   }
@@ -38,7 +40,7 @@ class FourierBasis extends Basis {
   }
 
   computeC() {
-    const powerRange = math.range(0, this.order + 1).toArray();
+    const powerRange = math.range(0, this.order + 1).toArray().map(x => Math.PI * x);
     const possiblePowers = new Array(this.variables).fill(powerRange);
     return cartesianProduct(...possiblePowers).toArray();
   }

--- a/packages/baselines/function-approximators/generic/linear/bases/fourier.spec.js
+++ b/packages/baselines/function-approximators/generic/linear/bases/fourier.spec.js
@@ -18,6 +18,8 @@ it('computes features', () => {
   expect(features[6]).toBeCloseTo(-0.588, 3);
 });
 
+const toNormal = matr => matr.map(arr => arr.map(v => v / Math.PI));
+
 describe('c', () => {
   it('computes c correctly for 2x0', () => {
     const basis = new FourierBasis({
@@ -34,7 +36,7 @@ describe('c', () => {
       order: 1,
     });
 
-    expect(basis.c).toEqual([[0, 0], [1, 0], [0, 1], [1, 1]]);
+    expect(toNormal(basis.c)).toEqual([[0, 0], [1, 0], [0, 1], [1, 1]]);
   });
 
   it('computes c correctly for 2x2', () => {
@@ -43,7 +45,7 @@ describe('c', () => {
       order: 2,
     });
 
-    expect(basis.c).toEqual([
+    expect(toNormal(basis.c)).toEqual([
       [0, 0],
       [1, 0],
       [2, 0],
@@ -62,7 +64,7 @@ describe('c', () => {
       order: 1,
     });
 
-    expect(basis.c).toEqual([
+    expect(toNormal(basis.c)).toEqual([
       [0, 0, 0],
       [1, 0, 0],
       [0, 1, 0],

--- a/packages/baselines/function-approximators/generic/linear/bases/fourier.spec.js
+++ b/packages/baselines/function-approximators/generic/linear/bases/fourier.spec.js
@@ -18,7 +18,7 @@ it('computes features', () => {
   expect(features[6]).toBeCloseTo(-0.588, 3);
 });
 
-const toNormal = matr => matr.map(arr => arr.map(v => v / Math.PI));
+const removePI = matr => matr.map(arr => arr.map(v => v / Math.PI));
 
 describe('c', () => {
   it('computes c correctly for 2x0', () => {
@@ -36,7 +36,7 @@ describe('c', () => {
       order: 1,
     });
 
-    expect(toNormal(basis.c)).toEqual([[0, 0], [1, 0], [0, 1], [1, 1]]);
+    expect(removePI(basis.c)).toEqual([[0, 0], [1, 0], [0, 1], [1, 1]]);
   });
 
   it('computes c correctly for 2x2', () => {
@@ -45,7 +45,7 @@ describe('c', () => {
       order: 2,
     });
 
-    expect(toNormal(basis.c)).toEqual([
+    expect(removePI(basis.c)).toEqual([
       [0, 0],
       [1, 0],
       [2, 0],
@@ -64,7 +64,7 @@ describe('c', () => {
       order: 1,
     });
 
-    expect(toNormal(basis.c)).toEqual([
+    expect(removePI(basis.c)).toEqual([
       [0, 0, 0],
       [1, 0, 0],
       [0, 1, 0],


### PR DESCRIPTION
Gives 2.5x speed up pretty much across the board.